### PR TITLE
Config settings for interval and fix for ticker colors

### DIFF
--- a/lib/atom-bitcoin.coffee
+++ b/lib/atom-bitcoin.coffee
@@ -3,3 +3,6 @@ AtomBitcoinStatusBarView = require './atom-bitcoin-status-bar-view'
 module.exports =
   activate: ->
     @atomBitcoinStatusBarView = new AtomBitcoinStatusBarView()
+
+  configDefaults:
+    interval: 5


### PR DESCRIPTION
added interval config setting. users can now specify an interval for update in the settings. added text to display for initial load and made display into it's own function. fixed issue with swapped colors for price going up or down.
